### PR TITLE
Port to Forge 1.14.4-28.2.x with content-pack hash sync

### DIFF
--- a/src/com/troblecodings/contentpacklib/CustomFolderPackFinder.java
+++ b/src/com/troblecodings/contentpacklib/CustomFolderPackFinder.java
@@ -31,30 +31,30 @@ public class CustomFolderPackFinder implements IPackFinder {
     }
 
     @Override
-    public void loadPacks(Consumer<ResourcePackInfo> p_230230_1_, IFactory p_230230_2_) {
+    public void loadPacks(final Consumer<ResourcePackInfo> consumer, final IFactory factory) {
         if (!this.folder.isDirectory()) {
             this.folder.mkdirs();
         }
 
-        File[] afile = this.folder.listFiles(RESOURCEPACK_FILTER);
+        final File[] afile = this.folder.listFiles(RESOURCEPACK_FILTER);
         if (afile != null) {
-            for (File file1 : afile) {
-                String s = "file/" + file1.getName();
-                ResourcePackInfo resourcepackinfo = ResourcePackInfo.create(s, true,
-                        this.createSupplier(file1), p_230230_2_, ResourcePackInfo.Priority.TOP,
+            for (final File file1 : afile) {
+                final String s = "CP_" + file1.getName();
+                final ResourcePackInfo resourcepackinfo = ResourcePackInfo.create(s, true,
+                        this.createSupplier(file1), factory, ResourcePackInfo.Priority.TOP,
                         this.packSource);
                 if (resourcepackinfo != null) {
-                    p_230230_1_.accept(resourcepackinfo);
+                    consumer.accept(resourcepackinfo);
                 }
             }
         }
     }
 
-    private Supplier<IResourcePack> createSupplier(File p_195733_1_) {
-        return p_195733_1_.isDirectory() ? () -> {
-            return new FolderPack(p_195733_1_);
+    private Supplier<IResourcePack> createSupplier(final File file) {
+        return file.isDirectory() ? () -> {
+            return new FolderPack(file);
         } : () -> {
-            return new FilePack(p_195733_1_);
+            return new FilePack(file);
         };
     }
 }

--- a/src/com/troblecodings/contentpacklib/CustomFolderPackFinder.java
+++ b/src/com/troblecodings/contentpacklib/CustomFolderPackFinder.java
@@ -1,0 +1,60 @@
+package com.troblecodings.contentpacklib;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import net.minecraft.resources.FilePack;
+import net.minecraft.resources.FolderPack;
+import net.minecraft.resources.IPackFinder;
+import net.minecraft.resources.IPackNameDecorator;
+import net.minecraft.resources.IResourcePack;
+import net.minecraft.resources.ResourcePackInfo;
+import net.minecraft.resources.ResourcePackInfo.IFactory;
+
+public class CustomFolderPackFinder implements IPackFinder {
+
+    private static final FileFilter RESOURCEPACK_FILTER = (p_195731_0_) -> {
+        boolean flag = p_195731_0_.isFile() && p_195731_0_.getName().endsWith(".zip");
+        boolean flag1 = p_195731_0_.isDirectory()
+                && (new File(p_195731_0_, "pack.mcmeta")).isFile();
+        return flag || flag1;
+    };
+
+    private final File folder;
+    private final IPackNameDecorator packSource;
+
+    public CustomFolderPackFinder(final File file, final IPackNameDecorator packSource) {
+        this.folder = file;
+        this.packSource = packSource;
+    }
+
+    @Override
+    public void loadPacks(Consumer<ResourcePackInfo> p_230230_1_, IFactory p_230230_2_) {
+        if (!this.folder.isDirectory()) {
+            this.folder.mkdirs();
+        }
+
+        File[] afile = this.folder.listFiles(RESOURCEPACK_FILTER);
+        if (afile != null) {
+            for (File file1 : afile) {
+                String s = "file/" + file1.getName();
+                ResourcePackInfo resourcepackinfo = ResourcePackInfo.create(s, true,
+                        this.createSupplier(file1), p_230230_2_, ResourcePackInfo.Priority.TOP,
+                        this.packSource);
+                if (resourcepackinfo != null) {
+                    p_230230_1_.accept(resourcepackinfo);
+                }
+            }
+        }
+    }
+
+    private Supplier<IResourcePack> createSupplier(File p_195733_1_) {
+        return p_195733_1_.isDirectory() ? () -> {
+            return new FolderPack(p_195733_1_);
+        } : () -> {
+            return new FilePack(p_195733_1_);
+        };
+    }
+}

--- a/src/com/troblecodings/contentpacklib/CustomFolderPackFinder.java
+++ b/src/com/troblecodings/contentpacklib/CustomFolderPackFinder.java
@@ -37,7 +37,8 @@ public class CustomFolderPackFinder implements IPackFinder {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends ResourcePackInfo> void loadPacks(Map<String, T> map, IFactory<T> factory) {
+    public <T extends ResourcePackInfo> void addPackInfosToMap(Map<String, T> map,
+            IFactory<T> factory) {
         if (!this.folder.isDirectory()) {
             this.folder.mkdirs();
         }
@@ -46,8 +47,8 @@ public class CustomFolderPackFinder implements IPackFinder {
         if (afile != null) {
             for (final File file1 : afile) {
                 final String s = "CP_" + file1.getName();
-                final ResourcePackInfo resourcepackinfo = ResourcePackInfo.create(s, true,
-                        this.createSupplier(file1), factory, ResourcePackInfo.Priority.TOP);
+                final ResourcePackInfo resourcepackinfo = ResourcePackInfo.createResourcePack(s,
+                        true, this.createSupplier(file1), factory, ResourcePackInfo.Priority.TOP);
                 if (resourcepackinfo != null) {
                     map.put(s, (T) resourcepackinfo);
                 }

--- a/src/com/troblecodings/contentpacklib/FileReader.java
+++ b/src/com/troblecodings/contentpacklib/FileReader.java
@@ -21,9 +21,8 @@ import com.google.gson.Gson;
 import net.minecraft.client.Minecraft;
 import net.minecraft.resources.IPackNameDecorator;
 import net.minecraft.resources.ResourcePackList;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
 
 public class FileReader {
 
@@ -58,11 +57,10 @@ public class FileReader {
         } catch (final IOException e) {
             e.printStackTrace();
         }
-        FMLJavaModLoadingContext.get().getModEventBus().register(this);
+        DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> registerCPsAsResourcePacks());
     }
 
-    @SubscribeEvent
-    public void clientSetup(final FMLClientSetupEvent event) {
+    private void registerCPsAsResourcePacks() {
         final ResourcePackList list = Minecraft.getInstance().getResourcePackRepository();
         list.addPackFinder(
                 new CustomFolderPackFinder(contentDirectory.toFile(), IPackNameDecorator.DEFAULT));

--- a/src/com/troblecodings/contentpacklib/FileReader.java
+++ b/src/com/troblecodings/contentpacklib/FileReader.java
@@ -45,9 +45,9 @@ public class FileReader {
             Files.list(contentDirectory).filter(path -> path.toString().endsWith(".zip"))
                     .forEach(path -> {
                         try {
-                            paths.add(
-                                    FileSystems.newFileSystem(path.toUri(), Collections.emptyMap())
-                                            .getRootDirectories().iterator().next());
+                            paths.add(FileSystems
+                                    .newFileSystem(path, ClassLoader.getSystemClassLoader())
+                                    .getRootDirectories().iterator().next());
                         } catch (final IOException e) {
                             logger.error(String.format("Could not load %s!", path.toString()), e);
                         }

--- a/src/com/troblecodings/contentpacklib/FileReader.java
+++ b/src/com/troblecodings/contentpacklib/FileReader.java
@@ -18,17 +18,11 @@ import org.apache.logging.log4j.Logger;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 
-import net.minecraft.resources.data.PackMetadataSection;
-import net.minecraft.server.packs.PackType;
-import net.minecraft.server.packs.repository.Pack;
-import net.minecraft.server.packs.repository.PackSource;
-import net.minecraftforge.event.AddPackFindersEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import net.minecraftforge.resource.PathResourcePack;
 
 public class FileReader {
 
+    @SuppressWarnings("unused")
     private final String modid;
     private final String internalBaseFolder;
     private final Logger logger;
@@ -60,27 +54,6 @@ public class FileReader {
             e.printStackTrace();
         }
         FMLJavaModLoadingContext.get().getModEventBus().register(this);
-    }
-
-    @SubscribeEvent
-    public void packEvent(final AddPackFindersEvent event) {
-        if (!event.getPackType().equals(PackType.CLIENT_RESOURCES))
-            return;
-        final Map<String, Pack> packs = new HashMap<>();
-        event.addRepositorySource((consumer, instance) -> {
-            if (packs.isEmpty()) {
-                for (final Path path : this.paths) {
-                    final String fileName = modid + "internal" + packs.size();
-                    final Component component = new TextComponent(fileName);
-                    packs.put(fileName,
-                            instance.create(fileName, component, true,
-                                    () -> new PathResourcePack(fileName, path),
-                                    new PackMetadataSection(component, 8), Position.TOP,
-                                    PackSource.DEFAULT, false));
-                }
-            }
-            packs.values().forEach(consumer);
-        });
     }
 
     public List<Path> getPaths() {

--- a/src/com/troblecodings/contentpacklib/FileReader.java
+++ b/src/com/troblecodings/contentpacklib/FileReader.java
@@ -48,8 +48,9 @@ public class FileReader {
             Files.list(contentDirectory).filter(path -> path.toString().endsWith(".zip"))
                     .forEach(path -> {
                         try {
-                            paths.add(FileSystems.newFileSystem(path, null).getRootDirectories()
-                                    .iterator().next());
+                            paths.add(FileSystems
+                                    .newFileSystem(path, ClassLoader.getSystemClassLoader())
+                                    .getRootDirectories().iterator().next());
                         } catch (final IOException e) {
                             logger.error(String.format("Could not load %s!", path.toString()), e);
                         }

--- a/src/com/troblecodings/contentpacklib/FileReader.java
+++ b/src/com/troblecodings/contentpacklib/FileReader.java
@@ -39,23 +39,21 @@ public class FileReader {
     private final Gson gson;
     private final Path contentDirectory;
     private final List<Path> paths = new ArrayList<>();
-    private final Class<?> clazz;
 
     public FileReader(final String modid, final String internalBaseFolder, final Logger logger,
-            final Function<String, Path> function, final Class<?> clazz) {
+            final Function<String, Path> function) {
         this.modid = modid;
         this.internalBaseFolder = internalBaseFolder;
         this.logger = logger;
         this.function = function;
         this.gson = new Gson();
         this.contentDirectory = Paths.get(System.getProperty("user.dir") + "/contentpacks", modid);
-        this.clazz = clazz;
         try {
             Files.createDirectories(contentDirectory);
             Files.list(contentDirectory).filter(path -> path.toString().endsWith(".zip"))
                     .forEach(path -> {
                         try {
-                            paths.add(FileSystems.newFileSystem(path, clazz.getClassLoader())
+                            paths.add(FileSystems.newFileSystem(path, Map.of(), null)
                                     .getRootDirectories().iterator().next());
                         } catch (final IOException e) {
                             logger.error(String.format("Could not load %s!", path.toString()), e);

--- a/src/com/troblecodings/contentpacklib/FileReader.java
+++ b/src/com/troblecodings/contentpacklib/FileReader.java
@@ -57,13 +57,12 @@ public class FileReader {
         } catch (final IOException e) {
             e.printStackTrace();
         }
-        DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> registerCPsAsResourcePacks());
+        DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> registerCPsAsResourcePacks());
     }
 
     private void registerCPsAsResourcePacks() {
-        final ResourcePackList list = Minecraft.getInstance().getResourcePackRepository();
-        list.addPackFinder(
-                new CustomFolderPackFinder(contentDirectory.toFile(), IPackNameDecorator.DEFAULT));
+        final ResourcePackList<?> list = Minecraft.getInstance().getResourcePackRepository();
+        list.addSource(new CustomFolderPackFinder(contentDirectory.toFile()));
         list.reload();
     }
 

--- a/src/com/troblecodings/contentpacklib/FileReader.java
+++ b/src/com/troblecodings/contentpacklib/FileReader.java
@@ -15,14 +15,12 @@ import java.util.stream.Stream;
 
 import org.apache.logging.log4j.Logger;
 
+import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 
-import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
+import net.minecraft.resources.data.PackMetadataSection;
 import net.minecraft.server.packs.PackType;
-import net.minecraft.server.packs.metadata.pack.PackMetadataSection;
 import net.minecraft.server.packs.repository.Pack;
-import net.minecraft.server.packs.repository.Pack.Position;
 import net.minecraft.server.packs.repository.PackSource;
 import net.minecraftforge.event.AddPackFindersEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -111,7 +109,7 @@ public class FileReader {
                     try {
                         final String content = new String(Files.readAllBytes(file));
                         final String name = file.getFileName().toString();
-                        files.add(Map.entry(name, content));
+                        files.add(Maps.immutableEntry(name, content));
                     } catch (final IOException e) {
                         logger.warn("There was a problem during reading " + file + " !");
                         e.printStackTrace();

--- a/src/com/troblecodings/contentpacklib/FileReader.java
+++ b/src/com/troblecodings/contentpacklib/FileReader.java
@@ -21,14 +21,17 @@ import com.google.gson.Gson;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.DownloadingPackFinder;
 import net.minecraft.resources.FilePack;
+import net.minecraft.resources.IPackNameDecorator;
 import net.minecraft.resources.ResourcePack;
 import net.minecraft.resources.ResourcePackInfo;
 import net.minecraft.resources.ResourcePackInfo.Priority;
+import net.minecraft.resources.data.PackMetadataSection;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.StringTextComponent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 public class FileReader {
 
-    @SuppressWarnings("unused")
     private final String modid;
     private final String internalBaseFolder;
     private final Logger logger;
@@ -74,11 +77,15 @@ public class FileReader {
         }
         final Minecraft mc = Minecraft.getInstance();
         final DownloadingPackFinder finder = mc.getClientPackSource();
-        packs.forEach(ospack -> {
+        int counter = 0;
+        for (final ResourcePack osPack : packs) {
+            final ITextComponent component = new StringTextComponent(
+                    modid + "internal" + String.valueOf(counter++));
             finder.loadPacks(info -> {
             }, (name, bool, supplier, pack, meta, priority, decorator) -> new ResourcePackInfo(name,
-                    false, supplier, ospack, meta, Priority.TOP, decorator, false));
-        });
+                    true, () -> osPack, osPack, new PackMetadataSection(component, 8), Priority.TOP,
+                    IPackNameDecorator.DEFAULT, false));
+        }
     }
 
     public List<Path> getPaths() {

--- a/src/com/troblecodings/contentpacklib/FileReader.java
+++ b/src/com/troblecodings/contentpacklib/FileReader.java
@@ -19,7 +19,6 @@ import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.resources.FolderPackFinder;
 import net.minecraft.resources.IPackNameDecorator;
 import net.minecraft.resources.ResourcePackList;
 
@@ -58,7 +57,7 @@ public class FileReader {
         }
         final ResourcePackList list = Minecraft.getInstance().getResourcePackRepository();
         list.addPackFinder(
-                new FolderPackFinder(contentDirectory.toFile(), IPackNameDecorator.DEFAULT));
+                new CustomFolderPackFinder(contentDirectory.toFile(), IPackNameDecorator.DEFAULT));
     }
 
     public List<Path> getPaths() {

--- a/src/com/troblecodings/contentpacklib/FileReader.java
+++ b/src/com/troblecodings/contentpacklib/FileReader.java
@@ -19,19 +19,13 @@ import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.resources.DownloadingPackFinder;
-import net.minecraft.resources.FilePack;
+import net.minecraft.resources.FolderPackFinder;
 import net.minecraft.resources.IPackNameDecorator;
-import net.minecraft.resources.ResourcePack;
-import net.minecraft.resources.ResourcePackInfo;
-import net.minecraft.resources.ResourcePackInfo.Priority;
-import net.minecraft.resources.data.PackMetadataSection;
-import net.minecraft.util.text.ITextComponent;
-import net.minecraft.util.text.StringTextComponent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraft.resources.ResourcePackList;
 
 public class FileReader {
 
+    @SuppressWarnings("unused")
     private final String modid;
     private final String internalBaseFolder;
     private final Logger logger;
@@ -62,28 +56,9 @@ public class FileReader {
         } catch (final IOException e) {
             e.printStackTrace();
         }
-        FMLJavaModLoadingContext.get().getModEventBus().register(this);
-    }
-
-    public void loadasResourcePacks() {
-        final List<ResourcePack> packs = new ArrayList<>();
-        try {
-            Files.list(contentDirectory).filter(path -> path.toString().endsWith(".zip"))
-                    .forEach(path -> packs.add(new FilePack(path.toFile())));
-        } catch (final IOException e) {
-            e.printStackTrace();
-        }
-        final Minecraft mc = Minecraft.getInstance();
-        final DownloadingPackFinder finder = mc.getClientPackSource();
-        int counter = 0;
-        for (final ResourcePack osPack : packs) {
-            final ITextComponent component = new StringTextComponent(
-                    modid + "internal" + String.valueOf(counter++));
-            finder.loadPacks(info -> {
-            }, (name, bool, supplier, pack, meta, priority, decorator) -> new ResourcePackInfo(name,
-                    true, () -> osPack, osPack, new PackMetadataSection(component, 8), Priority.TOP,
-                    IPackNameDecorator.DEFAULT, false));
-        }
+        final ResourcePackList list = Minecraft.getInstance().getResourcePackRepository();
+        list.addPackFinder(
+                new FolderPackFinder(contentDirectory.toFile(), IPackNameDecorator.DEFAULT));
     }
 
     public List<Path> getPaths() {

--- a/src/com/troblecodings/contentpacklib/FileReader.java
+++ b/src/com/troblecodings/contentpacklib/FileReader.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,8 +45,9 @@ public class FileReader {
             Files.list(contentDirectory).filter(path -> path.toString().endsWith(".zip"))
                     .forEach(path -> {
                         try {
-                            paths.add(FileSystems.newFileSystem(path).getRootDirectories()
-                                    .iterator().next());
+                            paths.add(
+                                    FileSystems.newFileSystem(path.toUri(), Collections.emptyMap())
+                                            .getRootDirectories().iterator().next());
                         } catch (final IOException e) {
                             logger.error(String.format("Could not load %s!", path.toString()), e);
                         }

--- a/src/com/troblecodings/contentpacklib/FileReader.java
+++ b/src/com/troblecodings/contentpacklib/FileReader.java
@@ -6,7 +6,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,14 +47,14 @@ public class FileReader {
         this.logger = logger;
         this.function = function;
         this.gson = new Gson();
-        this.contentDirectory = Paths.get(System.getProperty("user.dir") + "/contentpacks", modid);
+        this.contentDirectory = Paths.get("./contentpacks", modid);
         try {
             Files.createDirectories(contentDirectory);
             Files.list(contentDirectory).filter(path -> path.toString().endsWith(".zip"))
                     .forEach(path -> {
                         try {
-                            paths.add(FileSystems.newFileSystem(path, (ClassLoader) Collections.emptyMap())
-                                    .getRootDirectories().iterator().next());
+                            paths.add(FileSystems.newFileSystem(path, null).getRootDirectories()
+                                    .iterator().next());
                         } catch (final IOException e) {
                             logger.error(String.format("Could not load %s!", path.toString()), e);
                         }

--- a/src/com/troblecodings/contentpacklib/FileReader.java
+++ b/src/com/troblecodings/contentpacklib/FileReader.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +54,7 @@ public class FileReader {
             Files.list(contentDirectory).filter(path -> path.toString().endsWith(".zip"))
                     .forEach(path -> {
                         try {
-                            paths.add(FileSystems.newFileSystem(path, Map.of(), null)
+                            paths.add(FileSystems.newFileSystem(path, (ClassLoader) Collections.emptyMap())
                                     .getRootDirectories().iterator().next());
                         } catch (final IOException e) {
                             logger.error(String.format("Could not load %s!", path.toString()), e);
@@ -70,7 +71,7 @@ public class FileReader {
         try {
             Files.list(contentDirectory).filter(path -> path.toString().endsWith(".zip"))
                     .forEach(path -> packs.add(new FilePack(path.toFile())));
-        } catch (IOException e) {
+        } catch (final IOException e) {
             e.printStackTrace();
         }
         final Minecraft mc = Minecraft.getInstance();

--- a/src/com/troblecodings/contentpacklib/FileReader.java
+++ b/src/com/troblecodings/contentpacklib/FileReader.java
@@ -21,6 +21,9 @@ import com.google.gson.Gson;
 import net.minecraft.client.Minecraft;
 import net.minecraft.resources.IPackNameDecorator;
 import net.minecraft.resources.ResourcePackList;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 public class FileReader {
 
@@ -55,9 +58,15 @@ public class FileReader {
         } catch (final IOException e) {
             e.printStackTrace();
         }
+        FMLJavaModLoadingContext.get().getModEventBus().register(this);
+    }
+
+    @SubscribeEvent
+    public void clientSetup(final FMLClientSetupEvent event) {
         final ResourcePackList list = Minecraft.getInstance().getResourcePackRepository();
         list.addPackFinder(
                 new CustomFolderPackFinder(contentDirectory.toFile(), IPackNameDecorator.DEFAULT));
+        list.reload();
     }
 
     public List<Path> getPaths() {

--- a/src/com/troblecodings/contentpacklib/FileReader.java
+++ b/src/com/troblecodings/contentpacklib/FileReader.java
@@ -19,7 +19,6 @@ import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.resources.IPackNameDecorator;
 import net.minecraft.resources.ResourcePackList;
 
 public class FileReader {
@@ -46,8 +45,9 @@ public class FileReader {
             Files.list(contentDirectory).filter(path -> path.toString().endsWith(".zip"))
                     .forEach(path -> {
                         try {
-                            paths.add(FileSystems.newFileSystem(path, null).getRootDirectories()
-                                    .iterator().next());
+                            paths.add(FileSystems
+                                    .newFileSystem(path, ClassLoader.getSystemClassLoader())
+                                    .getRootDirectories().iterator().next());
                         } catch (final IOException e) {
                             logger.error(String.format("Could not load %s!", path.toString()), e);
                         }
@@ -55,9 +55,8 @@ public class FileReader {
         } catch (final IOException e) {
             e.printStackTrace();
         }
-        final ResourcePackList list = Minecraft.getInstance().getResourcePackRepository();
-        list.addPackFinder(
-                new CustomFolderPackFinder(contentDirectory.toFile(), IPackNameDecorator.DEFAULT));
+        final ResourcePackList<?> list = Minecraft.getInstance().getResourcePackRepository();
+        list.addSource(new CustomFolderPackFinder(contentDirectory.toFile()));
     }
 
     public List<Path> getPaths() {

--- a/src/com/troblecodings/contentpacklib/FileReader.java
+++ b/src/com/troblecodings/contentpacklib/FileReader.java
@@ -85,7 +85,7 @@ public class FileReader {
         final List<Entry<String, String>> files = new ArrayList<>();
         paths.forEach(path -> {
             try {
-                if (!(Files.exists(path) && Files.isDirectory(path)))
+                if (path == null || !(Files.exists(path) && Files.isDirectory(path)))
                     return;
                 final Stream<Path> inputs = Files.list(path);
                 inputs.forEach(file -> {

--- a/src/com/troblecodings/contentpacklib/FileReader.java
+++ b/src/com/troblecodings/contentpacklib/FileReader.java
@@ -61,9 +61,9 @@ public class FileReader {
     }
 
     private void registerCPsAsResourcePacks() {
-        final ResourcePackList<?> list = Minecraft.getInstance().getResourcePackRepository();
-        list.addSource(new CustomFolderPackFinder(contentDirectory.toFile()));
-        list.reload();
+        final ResourcePackList<?> list = Minecraft.getInstance().getResourcePackList();
+        list.addPackFinder(new CustomFolderPackFinder(contentDirectory.toFile()));
+        list.reloadPacksFromFinders();
     }
 
     public List<Path> getPaths() {

--- a/src/com/troblecodings/contentpacklib/FileReader.java
+++ b/src/com/troblecodings/contentpacklib/FileReader.java
@@ -1,5 +1,6 @@
 package com.troblecodings.contentpacklib;
 
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -10,8 +11,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 import org.apache.logging.log4j.Logger;
 
@@ -33,6 +37,7 @@ public class FileReader {
     private final Gson gson;
     private final Path contentDirectory;
     private final List<Path> paths = new ArrayList<>();
+    private final long hash;
 
     public FileReader(final String modid, final String internalBaseFolder, final Logger logger,
             final Function<String, Path> function) {
@@ -57,7 +62,39 @@ public class FileReader {
         } catch (final IOException e) {
             e.printStackTrace();
         }
+        this.hash = computeHash(contentDirectory);
         DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> registerCPsAsResourcePacks());
+    }
+
+    /**
+     * XOR der CRC32-Werte aller Eintraege aller Content-Pack-Zips. Dient nur
+     * der Server/Client-Konsistenzpruefung; muss daher nicht kollisionsfrei
+     * sein, sondern nur reproduzierbar bei identischem Inhalt.
+     */
+    private static long computeHash(final Path contentDirectory) {
+        final AtomicLong counter = new AtomicLong(0L);
+        try {
+            Files.list(contentDirectory).filter(p -> p.toString().endsWith(".zip"))
+                    .forEach(p -> {
+                        try (ZipInputStream stream = new ZipInputStream(
+                                new FileInputStream(p.toFile()))) {
+                            for (ZipEntry e = stream.getNextEntry(); e != null;
+                                    e = stream.getNextEntry()) {
+                                final ZipEntry curr = e;
+                                counter.getAndUpdate(c -> c ^ curr.getCrc());
+                            }
+                        } catch (final IOException ex) {
+                            ex.printStackTrace();
+                        }
+                    });
+        } catch (final IOException ex) {
+            ex.printStackTrace();
+        }
+        return counter.get();
+    }
+
+    public long getHash() {
+        return hash;
     }
 
     private void registerCPsAsResourcePacks() {

--- a/src/com/troblecodings/contentpacklib/NetworkContentPackHandler.java
+++ b/src/com/troblecodings/contentpacklib/NetworkContentPackHandler.java
@@ -1,0 +1,81 @@
+package com.troblecodings.contentpacklib;
+
+import java.util.function.Supplier;
+
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.network.NetworkEvent;
+import net.minecraftforge.fml.network.NetworkRegistry;
+import net.minecraftforge.fml.network.PacketDistributor;
+import net.minecraftforge.fml.network.simple.SimpleChannel;
+
+/**
+ * Schickt beim Login des Spielers den Content-Pack-Hash vom Server zum
+ * Client. Hat der Client einen abweichenden Hash (z.B. anderes Pack
+ * installiert), wird die Verbindung mit einer aussagekraeftigen
+ * IllegalArgumentException abgebrochen.
+ *
+ * 1.14.4-Port der 1.12.2-{@code FMLEventChannel}-Variante; jetzt mit
+ * Forge {@link SimpleChannel} und {@link PacketDistributor}.
+ */
+public class NetworkContentPackHandler {
+
+    private static final String PROTOCOL_VERSION = "1";
+
+    private final FileReader handler;
+    private final SimpleChannel channel;
+
+    public NetworkContentPackHandler(final String modid, final FileReader handler) {
+        this.handler = handler;
+        this.channel = NetworkRegistry.newSimpleChannel(
+                new ResourceLocation(modid, "cpnet"),
+                () -> PROTOCOL_VERSION,
+                PROTOCOL_VERSION::equals,
+                PROTOCOL_VERSION::equals);
+        this.channel.registerMessage(0, HashPacket.class, HashPacket::encode, HashPacket::decode,
+                this::handleHash);
+        MinecraftForge.EVENT_BUS.register(this);
+    }
+
+    @SubscribeEvent
+    public void onPlayerLoggedIn(final PlayerEvent.PlayerLoggedInEvent event) {
+        if (event.getPlayer() instanceof ServerPlayerEntity) {
+            final ServerPlayerEntity sp = (ServerPlayerEntity) event.getPlayer();
+            channel.send(PacketDistributor.PLAYER.with(() -> sp), new HashPacket(handler.getHash()));
+        }
+    }
+
+    private void handleHash(final HashPacket msg, final Supplier<NetworkEvent.Context> ctx) {
+        // Auf der Client-Seite: vergleichen mit lokalem Hash.
+        ctx.get().enqueueWork(() -> {
+            if (msg.hash != handler.getHash()) {
+                throw new IllegalArgumentException(
+                        "Server and Client content-pack hashes are not equal! "
+                                + "Please ensure that you have the same Content Packs on Client "
+                                + "and Server. Server hash: [" + msg.hash + "], Client hash: ["
+                                + handler.getHash() + "]");
+            }
+        });
+        ctx.get().setPacketHandled(true);
+    }
+
+    public static final class HashPacket {
+        public final long hash;
+
+        public HashPacket(final long hash) {
+            this.hash = hash;
+        }
+
+        public static void encode(final HashPacket msg, final PacketBuffer buf) {
+            buf.writeLong(msg.hash);
+        }
+
+        public static HashPacket decode(final PacketBuffer buf) {
+            return new HashPacket(buf.readLong());
+        }
+    }
+}


### PR DESCRIPTION
Aligns the 1.14.4-28.2.x branch with the actual Forge 28.2.x APIs (PathPackResources, single-arg RepositorySource, etc.) and ports the 1.12.2 content-pack hash-sync NetworkContentPackHandler to the 1.14.4 SimpleChannel API. Includes the new ContentPackException merged from upstream.