### PR TITLE
1.16.5: tolerate null paths + align with MCP snapshot

### DIFF
--- a/src/com/troblecodings/contentpacklib/ContentPackHandler.java
+++ b/src/com/troblecodings/contentpacklib/ContentPackHandler.java
@@ -121,6 +121,13 @@ public class ContentPackHandler {
     public List<Entry<String, String>> getFiles(final List<Path> paths) {
         final List<Entry<String, String>> files = new ArrayList<>();
         paths.forEach(path -> {
+            // Optional-Resource-Tolerance: ein Mod, der zB. keine
+            // armordefinitions hat, bekommt fuer den internen Lookup einen
+            // null-Pfad zurueck. Wir ignorieren das hier, statt NPE zu
+            // werfen.
+            if (path == null) {
+                return;
+            }
             try {
                 if (!(Files.exists(path) && Files.isDirectory(path)))
                     return;

--- a/src/com/troblecodings/contentpacklib/ContentPackHandler.java
+++ b/src/com/troblecodings/contentpacklib/ContentPackHandler.java
@@ -90,9 +90,13 @@ public class ContentPackHandler {
     }
 
     private void registerCPsAsResourcePacks() {
-        final ResourcePackList list = Minecraft.getInstance().getResourcePackRepository();
+        // 1.16.5-MCP-Mappings: Minecraft#getResourcePackList und
+        // ResourcePackList#reloadPacksFromFinders. In neueren MC-Versionen
+        // (Mojang-Mappings) heisst das getResourcePackRepository#reload --
+        // hier passt der MCP-Snapshot-Name zu unserem build.gradle.
+        final ResourcePackList list = Minecraft.getInstance().getResourcePackList();
         list.addPackFinder(new CustomFolderPackFinder(contentDirectory.toFile()));
-        list.reload();
+        list.reloadPacksFromFinders();
     }
 
     public long getHash() {

--- a/src/com/troblecodings/contentpacklib/CustomFolderPackFinder.java
+++ b/src/com/troblecodings/contentpacklib/CustomFolderPackFinder.java
@@ -37,7 +37,9 @@ public class CustomFolderPackFinder implements IPackFinder {
     }
 
     @Override
-    public void loadPacks(Consumer<ResourcePackInfo> consumer, IFactory factory) {
+    public void findPacks(Consumer<ResourcePackInfo> consumer, IFactory factory) {
+        // 1.16.5-MCP: Methode heisst findPacks (war loadPacks in 1.14).
+        // IPackNameDecorator.PLAIN ersetzt das frueher genutzte DEFAULT.
         if (!this.folder.isDirectory()) {
             this.folder.mkdirs();
         }
@@ -45,9 +47,9 @@ public class CustomFolderPackFinder implements IPackFinder {
         if (files != null) {
             for (final File file : files) {
                 final String s = "CP_" + file.getName();
-                final ResourcePackInfo resourcepackinfo = ResourcePackInfo.create(s, true,
-                        this.createSupplier(file), factory, ResourcePackInfo.Priority.TOP,
-                        IPackNameDecorator.DEFAULT);
+                final ResourcePackInfo resourcepackinfo = ResourcePackInfo.createResourcePack(s,
+                        true, this.createSupplier(file), factory, ResourcePackInfo.Priority.TOP,
+                        IPackNameDecorator.PLAIN);
                 if (resourcepackinfo != null) {
                     consumer.accept(resourcepackinfo);
                 }

--- a/src/com/troblecodings/contentpacklib/NetworkContentPackHandler.java
+++ b/src/com/troblecodings/contentpacklib/NetworkContentPackHandler.java
@@ -52,13 +52,15 @@ public class NetworkContentPackHandler {
     }
 
     private void sendTo(final PlayerEntity player, final ByteBuffer buf) {
+        // 1.16.5-MCP: NetHandler#sendPacket (war einfach send in den vom
+        // Upstream genutzten Mappings).
         final PacketBuffer buffer = new PacketBuffer(Unpooled.copiedBuffer(buf.array()));
         if (player instanceof ServerPlayerEntity) {
             final ServerPlayerEntity server = (ServerPlayerEntity) player;
-            server.connection.send(new SCustomPayloadPlayPacket(channelName, buffer));
+            server.connection.sendPacket(new SCustomPayloadPlayPacket(channelName, buffer));
         } else {
             final Minecraft mc = Minecraft.getInstance();
-            mc.getConnection().send(new CCustomPayloadPacket(channelName, buffer));
+            mc.getConnection().sendPacket(new CCustomPayloadPacket(channelName, buffer));
         }
     }
 }


### PR DESCRIPTION
Defends getFiles against null paths returned by optional internal resource lookups, and aligns method names with MCP snapshot 20210309-1.16.5.