### PR TITLE
Port to 1.20.4 (Pack-API + Custom-Payload-Stack rewrite)

### DIFF
--- a/src/com/troblecodings/contentpacklib/ContentPackHandler.java
+++ b/src/com/troblecodings/contentpacklib/ContentPackHandler.java
@@ -1,6 +1,5 @@
 package com.troblecodings.contentpacklib;
 
-import java.awt.TextComponent;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.FileSystems;
@@ -25,14 +24,12 @@ import com.google.gson.Gson;
 
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.packs.PackType;
-import net.minecraft.server.packs.metadata.pack.PackMetadataSection;
+import net.minecraft.server.packs.repository.FolderRepositorySource;
 import net.minecraft.server.packs.repository.Pack;
-import net.minecraft.server.packs.repository.Pack.Position;
 import net.minecraft.server.packs.repository.PackSource;
 import net.minecraftforge.event.AddPackFindersEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import net.minecraftforge.resource.PathResourcePack;
 
 public class ContentPackHandler {
 
@@ -101,19 +98,20 @@ public class ContentPackHandler {
         if (!event.getPackType().equals(PackType.CLIENT_RESOURCES))
             return;
         final Map<String, Pack> packs = new HashMap<>();
-        event.addRepositorySource((source) -> {
+        event.addRepositorySource((consumer) -> {
             if (packs.isEmpty()) {
                 for (final Path path : this.paths) {
                     final String fileName = modid + "internal" + packs.size();
-                    final Component component = new TextComponent(fileName);
+                    final Component component = Component.translatable(fileName);
+
                     packs.put(fileName,
-                            source.create(fileName, component, true,
-                                    () -> new PathResourcePack(fileName, path),
-                                    new PackMetadataSection(component, 8), Position.TOP,
-                                    PackSource.DEFAULT, false));
+                            Pack.create(fileName, component, true,
+                                    FolderRepositorySource.detectPackResources(path, true),
+                                    new Pack.Info(component, 8, null), PackType.CLIENT_RESOURCES,
+                                    Pack.Position.TOP, false, PackSource.SERVER));
                 }
             }
-            packs.values().forEach(source);
+            packs.values().forEach(consumer);
         });
     }
 

--- a/src/com/troblecodings/contentpacklib/ContentPackHandler.java
+++ b/src/com/troblecodings/contentpacklib/ContentPackHandler.java
@@ -1,5 +1,6 @@
 package com.troblecodings.contentpacklib;
 
+import java.awt.TextComponent;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.FileSystems;
@@ -23,7 +24,6 @@ import org.apache.logging.log4j.Logger;
 import com.google.gson.Gson;
 
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.metadata.pack.PackMetadataSection;
 import net.minecraft.server.packs.repository.Pack;
@@ -84,7 +84,7 @@ public class ContentPackHandler {
                             e.printStackTrace();
                         }
                     });
-        } catch (IOException e) {
+        } catch (final IOException e) {
             e.printStackTrace();
         }
         hash = counter.get();
@@ -101,19 +101,19 @@ public class ContentPackHandler {
         if (!event.getPackType().equals(PackType.CLIENT_RESOURCES))
             return;
         final Map<String, Pack> packs = new HashMap<>();
-        event.addRepositorySource((consumer, instance) -> {
+        event.addRepositorySource((source) -> {
             if (packs.isEmpty()) {
                 for (final Path path : this.paths) {
                     final String fileName = modid + "internal" + packs.size();
                     final Component component = new TextComponent(fileName);
                     packs.put(fileName,
-                            instance.create(fileName, component, true,
+                            source.create(fileName, component, true,
                                     () -> new PathResourcePack(fileName, path),
                                     new PackMetadataSection(component, 8), Position.TOP,
                                     PackSource.DEFAULT, false));
                 }
             }
-            packs.values().forEach(consumer);
+            packs.values().forEach(source);
         });
     }
 

--- a/src/com/troblecodings/contentpacklib/ContentPackHandler.java
+++ b/src/com/troblecodings/contentpacklib/ContentPackHandler.java
@@ -25,6 +25,7 @@ import com.google.gson.Gson;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.packs.PackType;
 import net.minecraft.server.packs.repository.Pack;
+import net.minecraft.server.packs.repository.PackCompatibility;
 import net.minecraft.server.packs.repository.PackSource;
 import net.minecraftforge.event.AddPackFindersEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -97,25 +98,33 @@ public class ContentPackHandler {
     public void packEvent(final AddPackFindersEvent event) {
         if (!event.getPackType().equals(PackType.CLIENT_RESOURCES))
             return;
-        // 1.19.4-Pack-API: RepositorySource#loadPacks ist single-arg
-        // (Consumer<Pack>), Pack.PackConstructor existiert nicht mehr. Wir
-        // umgehen Pack.readMetaAndCreate (liest pack.mcmeta vor und kann an
-        // Format-Mismatch zwischen Pack-Inhalt und MC-Version scheitern,
-        // wodurch ContentPacks komplett aus dem Loader fallen) und bauen
-        // Pack.Info selbst -- mit dem 1.19.4-Resource-Format 13. Forge's
-        // PathPackResources ist die mod-bundled-Variante, die mit den
-        // FileSystem-Paths aus eingebundenen Zips zurechtkommt.
+        // 1.20.4-Pack-API: Pack.Info nimmt PackCompatibility direkt (kein int format mehr) und
+        // eine overlays-Liste; Pack.create hat keinen PackType-Parameter mehr (er ergibt sich
+        // aus dem Pack.Info / Source). Wir setzen COMPATIBLE fest, damit alte ContentPacks mit
+        // anderem pack.mcmeta-Format nicht aus dem Loader fallen. Forge's PathPackResources ist
+        // die mod-bundled-Variante, die mit den FileSystem-Paths aus eingebundenen Zips zurechtkommt.
         event.addRepositorySource(consumer -> {
             int idx = 0;
             for (final Path path : this.paths) {
                 final String fileName = modid + "internal" + idx;
                 idx++;
-                final Pack.Info info = new Pack.Info(Component.literal(fileName), 15,
-                        net.minecraft.world.flag.FeatureFlagSet.of());
+                final Pack.Info info = new Pack.Info(Component.literal(fileName),
+                        PackCompatibility.COMPATIBLE,
+                        net.minecraft.world.flag.FeatureFlagSet.of(), List.of());
+                final Pack.ResourcesSupplier supplier = new Pack.ResourcesSupplier() {
+                    @Override
+                    public net.minecraft.server.packs.PackResources openPrimary(final String name) {
+                        return new PathPackResources(name, true, path);
+                    }
+
+                    @Override
+                    public net.minecraft.server.packs.PackResources openFull(final String name,
+                            final Pack.Info pInfo) {
+                        return openPrimary(name);
+                    }
+                };
                 final Pack pack = Pack.create(fileName, Component.literal(fileName), true,
-                        name -> new PathPackResources(name, true, path), info,
-                        PackType.CLIENT_RESOURCES, Pack.Position.TOP, false,
-                        PackSource.BUILT_IN);
+                        supplier, info, Pack.Position.TOP, false, PackSource.BUILT_IN);
                 if (pack != null) {
                     consumer.accept(pack);
                 }

--- a/src/com/troblecodings/contentpacklib/ContentPackHandler.java
+++ b/src/com/troblecodings/contentpacklib/ContentPackHandler.java
@@ -132,6 +132,13 @@ public class ContentPackHandler {
     public List<Entry<String, String>> getFiles(final List<Path> paths) {
         final List<Entry<String, String>> files = new ArrayList<>();
         paths.forEach(path -> {
+            // Optional-Resource-Tolerance: ein Mod, der zB. keine
+            // armordefinitions hat, bekommt fuer den internen Lookup einen
+            // null-Pfad zurueck. Wir ignorieren das hier, statt NPE zu
+            // werfen.
+            if (path == null) {
+                return;
+            }
             try {
                 if (!(Files.exists(path) && Files.isDirectory(path)))
                     return;

--- a/src/com/troblecodings/contentpacklib/ContentPackHandler.java
+++ b/src/com/troblecodings/contentpacklib/ContentPackHandler.java
@@ -22,9 +22,8 @@ import org.apache.logging.log4j.Logger;
 
 import com.google.gson.Gson;
 
-import net.minecraft.network.chat.Component;
+import net.minecraft.server.packs.FolderPackResources;
 import net.minecraft.server.packs.PackType;
-import net.minecraft.server.packs.repository.FolderRepositorySource;
 import net.minecraft.server.packs.repository.Pack;
 import net.minecraft.server.packs.repository.PackSource;
 import net.minecraftforge.event.AddPackFindersEvent;
@@ -97,21 +96,21 @@ public class ContentPackHandler {
     public void packEvent(final AddPackFindersEvent event) {
         if (!event.getPackType().equals(PackType.CLIENT_RESOURCES))
             return;
-        final Map<String, Pack> packs = new HashMap<>();
-        event.addRepositorySource((consumer) -> {
-            if (packs.isEmpty()) {
-                for (final Path path : this.paths) {
-                    final String fileName = modid + "internal" + packs.size();
-                    final Component component = Component.translatable(fileName);
-
-                    packs.put(fileName,
-                            Pack.create(fileName, component, true,
-                                    FolderRepositorySource.detectPackResources(path, true),
-                                    new Pack.Info(component, 8, null), PackType.CLIENT_RESOURCES,
-                                    Pack.Position.TOP, false, PackSource.SERVER));
+        // 1.19.2-Pack-API: Pack.create nimmt Supplier<PackResources> +
+        // PackConstructor + PackSource; FolderPackResources liest aus
+        // einem Verzeichnis. Ein Paket pro extrahiertem ContentPack-Pfad.
+        event.addRepositorySource((consumer, packConstructor) -> {
+            int idx = 0;
+            for (final Path path : this.paths) {
+                final String fileName = modid + "internal" + idx;
+                idx++;
+                final Pack pack = Pack.create(fileName, true,
+                        () -> new FolderPackResources(path.toFile()),
+                        packConstructor, Pack.Position.TOP, PackSource.BUILT_IN);
+                if (pack != null) {
+                    consumer.accept(pack);
                 }
             }
-            packs.values().forEach(consumer);
         });
     }
 

--- a/src/com/troblecodings/contentpacklib/ContentPackHandler.java
+++ b/src/com/troblecodings/contentpacklib/ContentPackHandler.java
@@ -22,8 +22,9 @@ import org.apache.logging.log4j.Logger;
 
 import com.google.gson.Gson;
 
-import net.minecraft.server.packs.FolderPackResources;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.packs.PackType;
+import net.minecraft.server.packs.PathPackResources;
 import net.minecraft.server.packs.repository.Pack;
 import net.minecraft.server.packs.repository.PackSource;
 import net.minecraftforge.event.AddPackFindersEvent;
@@ -96,17 +97,21 @@ public class ContentPackHandler {
     public void packEvent(final AddPackFindersEvent event) {
         if (!event.getPackType().equals(PackType.CLIENT_RESOURCES))
             return;
-        // 1.19.2-Pack-API: Pack.create nimmt Supplier<PackResources> +
-        // PackConstructor + PackSource; FolderPackResources liest aus
-        // einem Verzeichnis. Ein Paket pro extrahiertem ContentPack-Pfad.
-        event.addRepositorySource((consumer, packConstructor) -> {
+        // 1.19.4-Pack-API: RepositorySource#loadPacks ist single-arg
+        // (Consumer<Pack>), Pack.PackConstructor existiert nicht mehr.
+        // Pack.readMetaAndCreate liest pack.mcmeta selber aus den
+        // PathPackResources-Inhalten und baut den Pack.Info dazu --
+        // ContentPack-Zips bringen ihre eigene pack.mcmeta mit.
+        event.addRepositorySource(consumer -> {
             int idx = 0;
             for (final Path path : this.paths) {
                 final String fileName = modid + "internal" + idx;
                 idx++;
-                final Pack pack = Pack.create(fileName, true,
-                        () -> new FolderPackResources(path.toFile()),
-                        packConstructor, Pack.Position.TOP, PackSource.BUILT_IN);
+                final Pack pack = Pack.readMetaAndCreate(fileName,
+                        Component.literal(fileName), true,
+                        name -> new PathPackResources(name, path, true),
+                        PackType.CLIENT_RESOURCES, Pack.Position.TOP,
+                        PackSource.BUILT_IN);
                 if (pack != null) {
                     consumer.accept(pack);
                 }

--- a/src/com/troblecodings/contentpacklib/ContentPackHandler.java
+++ b/src/com/troblecodings/contentpacklib/ContentPackHandler.java
@@ -110,7 +110,7 @@ public class ContentPackHandler {
             for (final Path path : this.paths) {
                 final String fileName = modid + "internal" + idx;
                 idx++;
-                final Pack.Info info = new Pack.Info(Component.literal(fileName), 13,
+                final Pack.Info info = new Pack.Info(Component.literal(fileName), 15,
                         net.minecraft.world.flag.FeatureFlagSet.of());
                 final Pack pack = Pack.create(fileName, Component.literal(fileName), true,
                         name -> new PathPackResources(name, true, path), info,

--- a/src/com/troblecodings/contentpacklib/ContentPackHandler.java
+++ b/src/com/troblecodings/contentpacklib/ContentPackHandler.java
@@ -24,12 +24,12 @@ import com.google.gson.Gson;
 
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.packs.PackType;
-import net.minecraft.server.packs.PathPackResources;
 import net.minecraft.server.packs.repository.Pack;
 import net.minecraft.server.packs.repository.PackSource;
 import net.minecraftforge.event.AddPackFindersEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.resource.PathPackResources;
 
 public class ContentPackHandler {
 
@@ -98,19 +98,23 @@ public class ContentPackHandler {
         if (!event.getPackType().equals(PackType.CLIENT_RESOURCES))
             return;
         // 1.19.4-Pack-API: RepositorySource#loadPacks ist single-arg
-        // (Consumer<Pack>), Pack.PackConstructor existiert nicht mehr.
-        // Pack.readMetaAndCreate liest pack.mcmeta selber aus den
-        // PathPackResources-Inhalten und baut den Pack.Info dazu --
-        // ContentPack-Zips bringen ihre eigene pack.mcmeta mit.
+        // (Consumer<Pack>), Pack.PackConstructor existiert nicht mehr. Wir
+        // umgehen Pack.readMetaAndCreate (liest pack.mcmeta vor und kann an
+        // Format-Mismatch zwischen Pack-Inhalt und MC-Version scheitern,
+        // wodurch ContentPacks komplett aus dem Loader fallen) und bauen
+        // Pack.Info selbst -- mit dem 1.19.4-Resource-Format 13. Forge's
+        // PathPackResources ist die mod-bundled-Variante, die mit den
+        // FileSystem-Paths aus eingebundenen Zips zurechtkommt.
         event.addRepositorySource(consumer -> {
             int idx = 0;
             for (final Path path : this.paths) {
                 final String fileName = modid + "internal" + idx;
                 idx++;
-                final Pack pack = Pack.readMetaAndCreate(fileName,
-                        Component.literal(fileName), true,
-                        name -> new PathPackResources(name, path, true),
-                        PackType.CLIENT_RESOURCES, Pack.Position.TOP,
+                final Pack.Info info = new Pack.Info(Component.literal(fileName), 13,
+                        net.minecraft.world.flag.FeatureFlagSet.of());
+                final Pack pack = Pack.create(fileName, Component.literal(fileName), true,
+                        name -> new PathPackResources(name, true, path), info,
+                        PackType.CLIENT_RESOURCES, Pack.Position.TOP, false,
                         PackSource.BUILT_IN);
                 if (pack != null) {
                     consumer.accept(pack);

--- a/src/com/troblecodings/contentpacklib/NetworkContentPackHandler.java
+++ b/src/com/troblecodings/contentpacklib/NetworkContentPackHandler.java
@@ -9,7 +9,6 @@ import net.minecraft.network.protocol.game.ClientboundCustomPayloadPacket;
 import net.minecraft.network.protocol.game.ServerboundCustomPayloadPacket;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.server.network.ServerPlayerConnection;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerEvent.PlayerLoggedInEvent;
@@ -50,7 +49,7 @@ public class NetworkContentPackHandler {
     public void onPlayerJoin(final PlayerLoggedInEvent event) {
         final ByteBuffer buffer = ByteBuffer.allocate(8);
         buffer.putLong(handler.getHash());
-        sendTo(((ServerPlayerConnection) event).getPlayer(), buffer);
+        sendTo(event.getEntity(), buffer);
     }
 
     private void sendTo(final Player player, final ByteBuffer buf) {

--- a/src/com/troblecodings/contentpacklib/NetworkContentPackHandler.java
+++ b/src/com/troblecodings/contentpacklib/NetworkContentPackHandler.java
@@ -9,12 +9,13 @@ import net.minecraft.network.protocol.game.ClientboundCustomPayloadPacket;
 import net.minecraft.network.protocol.game.ServerboundCustomPayloadPacket;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerPlayerConnection;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerEvent.PlayerLoggedInEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.network.NetworkRegistry;
 import net.minecraftforge.network.NetworkEvent.ServerCustomPayloadEvent;
+import net.minecraftforge.network.NetworkRegistry;
 import net.minecraftforge.network.event.EventNetworkChannel;
 
 public class NetworkContentPackHandler {
@@ -49,7 +50,7 @@ public class NetworkContentPackHandler {
     public void onPlayerJoin(final PlayerLoggedInEvent event) {
         final ByteBuffer buffer = ByteBuffer.allocate(8);
         buffer.putLong(handler.getHash());
-        sendTo(event.getPlayer(), buffer);
+        sendTo(((ServerPlayerConnection) event).getPlayer(), buffer);
     }
 
     private void sendTo(final Player player, final ByteBuffer buf) {

--- a/src/com/troblecodings/contentpacklib/NetworkContentPackHandler.java
+++ b/src/com/troblecodings/contentpacklib/NetworkContentPackHandler.java
@@ -9,7 +9,6 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerEvent.PlayerLoggedInEvent;
 import net.minecraftforge.event.network.CustomPayloadEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.network.ChannelBuilder;
 import net.minecraftforge.network.EventNetworkChannel;
 import net.minecraftforge.network.PacketDistributor;
@@ -20,6 +19,12 @@ import net.minecraftforge.network.PacketDistributor;
  * {@link CustomPayloadEvent} (Server-/Client-Spaltung entfaellt) und versendet wird ueber
  * {@code channel.send(buf, PacketDistributor.PLAYER.with(...))}. Der Inhalt bleibt unveraendert
  * ein 8-Byte-Hash, der beim Login vom Server zum Client geschickt und auf Gleichheit geprueft wird.
+ *
+ * <p>Wichtig: der Payload-Handler haengt am {@link EventNetworkChannel} (channel-gefiltert), der
+ * Player-Join-Handler am globalen Event-Bus. Ein {@code registerObject(this)} + zusaetzliches
+ * {@code EVENT_BUS.register(this)} wuerde {@code onPayload} doppelt registrieren -- einmal
+ * channel-gefiltert, einmal global -- und der globale Aufruf bekaeme bei fremden Payloads
+ * {@code event.getPayload() == null} und wuerde NPEen.
  */
 public class NetworkContentPackHandler {
 
@@ -32,12 +37,11 @@ public class NetworkContentPackHandler {
                 .optional()
                 .eventNetworkChannel();
         this.handler = handler;
-        channel.registerObject(this);
-        MinecraftForge.EVENT_BUS.register(this);
+        channel.addListener(this::onPayload);
+        MinecraftForge.EVENT_BUS.addListener(this::onPlayerJoin);
     }
 
-    @SubscribeEvent
-    public void onPayload(final CustomPayloadEvent event) {
+    private void onPayload(final CustomPayloadEvent event) {
         final ByteBuffer buffer = event.getPayload().nioBuffer();
         final long serverHash = buffer.getLong();
         if (serverHash != handler.getHash()) {
@@ -49,8 +53,7 @@ public class NetworkContentPackHandler {
         event.getSource().setPacketHandled(true);
     }
 
-    @SubscribeEvent
-    public void onPlayerJoin(final PlayerLoggedInEvent event) {
+    private void onPlayerJoin(final PlayerLoggedInEvent event) {
         if (!(event.getEntity() instanceof ServerPlayer server)) {
             return;
         }

--- a/src/com/troblecodings/contentpacklib/NetworkContentPackHandler.java
+++ b/src/com/troblecodings/contentpacklib/NetworkContentPackHandler.java
@@ -3,37 +3,41 @@ package com.troblecodings.contentpacklib;
 import java.nio.ByteBuffer;
 
 import io.netty.buffer.Unpooled;
-import net.minecraft.client.Minecraft;
 import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.network.protocol.game.ClientboundCustomPayloadPacket;
-import net.minecraft.network.protocol.game.ServerboundCustomPayloadPacket;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerEvent.PlayerLoggedInEvent;
+import net.minecraftforge.event.network.CustomPayloadEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.network.NetworkEvent.ServerCustomPayloadEvent;
-import net.minecraftforge.network.NetworkRegistry;
-import net.minecraftforge.network.event.EventNetworkChannel;
+import net.minecraftforge.network.ChannelBuilder;
+import net.minecraftforge.network.EventNetworkChannel;
+import net.minecraftforge.network.PacketDistributor;
 
+/**
+ * In 1.20.4 ist der Custom-Payload-Stack komplett umgebaut. {@code NetworkRegistry.newEventChannel}
+ * existiert nicht mehr -- Channels werden via {@link ChannelBuilder} aufgebaut, das Event heisst
+ * {@link CustomPayloadEvent} (Server-/Client-Spaltung entfaellt) und versendet wird ueber
+ * {@code channel.send(buf, PacketDistributor.PLAYER.with(...))}. Der Inhalt bleibt unveraendert
+ * ein 8-Byte-Hash, der beim Login vom Server zum Client geschickt und auf Gleichheit geprueft wird.
+ */
 public class NetworkContentPackHandler {
 
     private final EventNetworkChannel channel;
-    private final ResourceLocation channelName;
     private final ContentPackHandler handler;
 
     public NetworkContentPackHandler(final String modid, final ContentPackHandler handler) {
-        this.channelName = new ResourceLocation(modid, "contentpackhandler");
-        this.channel = NetworkRegistry.newEventChannel(channelName, () -> modid,
-                modid::equalsIgnoreCase, modid::equalsIgnoreCase);
+        final ResourceLocation channelName = new ResourceLocation(modid, "contentpackhandler");
+        this.channel = ChannelBuilder.named(channelName)
+                .optional()
+                .eventNetworkChannel();
         this.handler = handler;
         channel.registerObject(this);
         MinecraftForge.EVENT_BUS.register(this);
     }
 
     @SubscribeEvent
-    public void serverEvent(final ServerCustomPayloadEvent event) {
+    public void onPayload(final CustomPayloadEvent event) {
         final ByteBuffer buffer = event.getPayload().nioBuffer();
         final long serverHash = buffer.getLong();
         if (serverHash != handler.getHash()) {
@@ -42,24 +46,18 @@ public class NetworkContentPackHandler {
                     + " Server Hash: [" + serverHash + "], Client Hash: [" + handler.getHash()
                     + "]");
         }
-        event.getSource().get().setPacketHandled(true);
+        event.getSource().setPacketHandled(true);
     }
 
     @SubscribeEvent
     public void onPlayerJoin(final PlayerLoggedInEvent event) {
+        if (!(event.getEntity() instanceof ServerPlayer server)) {
+            return;
+        }
         final ByteBuffer buffer = ByteBuffer.allocate(8);
         buffer.putLong(handler.getHash());
-        sendTo(event.getEntity(), buffer);
-    }
-
-    private void sendTo(final Player player, final ByteBuffer buf) {
-        final FriendlyByteBuf buffer = new FriendlyByteBuf(Unpooled.copiedBuffer(buf.position(0)));
-        if (player instanceof ServerPlayer) {
-            final ServerPlayer server = (ServerPlayer) player;
-            server.connection.send(new ClientboundCustomPayloadPacket(channelName, buffer));
-        } else {
-            final Minecraft mc = Minecraft.getInstance();
-            mc.getConnection().send(new ServerboundCustomPayloadPacket(channelName, buffer));
-        }
+        final FriendlyByteBuf friendly = new FriendlyByteBuf(
+                Unpooled.copiedBuffer(buffer.position(0)));
+        channel.send(friendly, PacketDistributor.PLAYER.with(server));
     }
 }


### PR DESCRIPTION
Rebuilds the network channel on the new ChannelBuilder/CustomPayloadEvent stack and splits payload + player-join handlers to dodge null-payload NPE on foreign payloads. Also aligns with the 1.20.4 Pack-API.