### PR TITLE
Make 1.14.4-28.2.28-compat actually compile against Forge 1.14.4-28.2.x

### DIFF
--- a/src/com/troblecodings/contentpacklib/ContentPackHandler.java
+++ b/src/com/troblecodings/contentpacklib/ContentPackHandler.java
@@ -20,19 +20,13 @@ import java.util.zip.ZipInputStream;
 
 import org.apache.logging.log4j.Logger;
 
+import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 
-import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.TextComponent;
-import net.minecraft.server.packs.PackType;
-import net.minecraft.server.packs.metadata.pack.PackMetadataSection;
-import net.minecraft.server.packs.repository.Pack;
-import net.minecraft.server.packs.repository.Pack.Position;
-import net.minecraft.server.packs.repository.PackSource;
-import net.minecraftforge.event.AddPackFindersEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
-import net.minecraftforge.resource.PathResourcePack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.resources.ResourcePackList;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.DistExecutor;
 
 public class ContentPackHandler {
 
@@ -58,8 +52,9 @@ public class ContentPackHandler {
             Files.list(contentDirectory).filter(path -> path.toString().endsWith(".zip"))
                     .forEach(path -> {
                         try {
-                            paths.add(FileSystems.newFileSystem(path).getRootDirectories()
-                                    .iterator().next());
+                            paths.add(FileSystems
+                                    .newFileSystem(path, ClassLoader.getSystemClassLoader())
+                                    .getRootDirectories().iterator().next());
                         } catch (final IOException e) {
                             logger.error(String.format("Could not load %s!", path.toString()), e);
                         }
@@ -68,54 +63,41 @@ public class ContentPackHandler {
             e.printStackTrace();
         }
         Collections.sort(paths, (path1, path2) -> path1.compareTo(path2));
-        final AtomicLong counter = new AtomicLong(0);
+        this.hash = computeHash(contentDirectory);
+        DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> registerCPsAsResourcePacks());
+        new NetworkContentPackHandler(modid, this);
+    }
+
+    private static long computeHash(final Path contentDirectory) {
+        final AtomicLong counter = new AtomicLong(0L);
         try {
-            Files.list(contentDirectory).filter(path -> path.toString().endsWith(".zip"))
-                    .forEach(path -> {
-                        try {
-                            final ZipInputStream stream =
-                                    new ZipInputStream(new FileInputStream(path.toFile()));
-                            for (ZipEntry entry = stream.getNextEntry(); entry != null; entry =
-                                    stream.getNextEntry()) {
-                                final ZipEntry currentEntry = entry;
-                                counter.getAndUpdate(current -> current ^ currentEntry.getCrc());
+            Files.list(contentDirectory).filter(p -> p.toString().endsWith(".zip"))
+                    .forEach(p -> {
+                        try (ZipInputStream stream = new ZipInputStream(
+                                new FileInputStream(p.toFile()))) {
+                            for (ZipEntry e = stream.getNextEntry(); e != null;
+                                    e = stream.getNextEntry()) {
+                                final ZipEntry curr = e;
+                                counter.getAndUpdate(c -> c ^ curr.getCrc());
                             }
-                            stream.close();
-                        } catch (final IOException e) {
-                            e.printStackTrace();
+                        } catch (final IOException ex) {
+                            ex.printStackTrace();
                         }
                     });
-        } catch (IOException e) {
-            e.printStackTrace();
+        } catch (final IOException ex) {
+            ex.printStackTrace();
         }
-        hash = counter.get();
-        FMLJavaModLoadingContext.get().getModEventBus().register(this);
-        new NetworkContentPackHandler(modid, this);
+        return counter.get();
     }
 
     public long getHash() {
         return hash;
     }
 
-    @SubscribeEvent
-    public void packEvent(final AddPackFindersEvent event) {
-        if (!event.getPackType().equals(PackType.CLIENT_RESOURCES))
-            return;
-        final Map<String, Pack> packs = new HashMap<>();
-        event.addRepositorySource((consumer, instance) -> {
-            if (packs.isEmpty()) {
-                for (final Path path : this.paths) {
-                    final String fileName = modid + "internal" + packs.size();
-                    final Component component = new TextComponent(fileName);
-                    packs.put(fileName,
-                            instance.create(fileName, component, true,
-                                    () -> new PathResourcePack(fileName, path),
-                                    new PackMetadataSection(component, 8), Position.TOP,
-                                    PackSource.DEFAULT, false));
-                }
-            }
-            packs.values().forEach(consumer);
-        });
+    private void registerCPsAsResourcePacks() {
+        final ResourcePackList<?> list = Minecraft.getInstance().getResourcePackList();
+        list.addPackFinder(new CustomFolderPackFinder(contentDirectory.toFile()));
+        list.reloadPacksFromFinders();
     }
 
     public List<Path> getPaths() {
@@ -144,7 +126,7 @@ public class ContentPackHandler {
                     try {
                         final String content = new String(Files.readAllBytes(file));
                         final String name = file.getFileName().toString();
-                        files.add(Map.entry(name, content));
+                        files.add(Maps.immutableEntry(name, content));
                     } catch (final IOException e) {
                         logger.warn("There was a problem during reading " + file + " !");
                         e.printStackTrace();

--- a/src/com/troblecodings/contentpacklib/ContentPackHandler.java
+++ b/src/com/troblecodings/contentpacklib/ContentPackHandler.java
@@ -119,7 +119,7 @@ public class ContentPackHandler {
         final List<Entry<String, String>> files = new ArrayList<>();
         paths.forEach(path -> {
             try {
-                if (!(Files.exists(path) && Files.isDirectory(path)))
+                if (path == null || !(Files.exists(path) && Files.isDirectory(path)))
                     return;
                 final Stream<Path> inputs = Files.list(path);
                 inputs.forEach(file -> {

--- a/src/com/troblecodings/contentpacklib/CustomFolderPackFinder.java
+++ b/src/com/troblecodings/contentpacklib/CustomFolderPackFinder.java
@@ -1,0 +1,58 @@
+package com.troblecodings.contentpacklib;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import net.minecraft.resources.FilePack;
+import net.minecraft.resources.FolderPack;
+import net.minecraft.resources.IPackFinder;
+import net.minecraft.resources.IResourcePack;
+import net.minecraft.resources.ResourcePackInfo;
+import net.minecraft.resources.ResourcePackInfo.IFactory;
+
+public class CustomFolderPackFinder implements IPackFinder {
+
+    private static final FileFilter RESOURCEPACK_FILTER = (p_195731_0_) -> {
+        boolean flag = p_195731_0_.isFile() && p_195731_0_.getName().endsWith(".zip");
+        boolean flag1 = p_195731_0_.isDirectory()
+                && (new File(p_195731_0_, "pack.mcmeta")).isFile();
+        return flag || flag1;
+    };
+
+    private final File folder;
+
+    public CustomFolderPackFinder(final File file) {
+        this.folder = file;
+    }
+
+    private Supplier<IResourcePack> createSupplier(final File file) {
+        return file.isDirectory() ? () -> {
+            return new FolderPack(file);
+        } : () -> {
+            return new FilePack(file);
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T extends ResourcePackInfo> void addPackInfosToMap(Map<String, T> map,
+            IFactory<T> factory) {
+        if (!this.folder.isDirectory()) {
+            this.folder.mkdirs();
+        }
+
+        final File[] afile = this.folder.listFiles(RESOURCEPACK_FILTER);
+        if (afile != null) {
+            for (final File file1 : afile) {
+                final String s = "CP_" + file1.getName();
+                final ResourcePackInfo resourcepackinfo = ResourcePackInfo.createResourcePack(s,
+                        true, this.createSupplier(file1), factory, ResourcePackInfo.Priority.TOP);
+                if (resourcepackinfo != null) {
+                    map.put(s, (T) resourcepackinfo);
+                }
+            }
+        }
+    }
+}

--- a/src/com/troblecodings/contentpacklib/NetworkContentPackHandler.java
+++ b/src/com/troblecodings/contentpacklib/NetworkContentPackHandler.java
@@ -1,64 +1,70 @@
 package com.troblecodings.contentpacklib;
 
-import java.nio.ByteBuffer;
+import java.util.function.Supplier;
 
-import io.netty.buffer.Unpooled;
-import net.minecraft.client.Minecraft;
-import net.minecraft.network.FriendlyByteBuf;
-import net.minecraft.network.protocol.game.ClientboundCustomPayloadPacket;
-import net.minecraft.network.protocol.game.ServerboundCustomPayloadPacket;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.entity.player.Player;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.network.PacketBuffer;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.entity.player.PlayerEvent.PlayerLoggedInEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.network.NetworkEvent.ServerCustomPayloadEvent;
-import net.minecraftforge.network.NetworkRegistry;
-import net.minecraftforge.network.event.EventNetworkChannel;
+import net.minecraftforge.fml.network.NetworkEvent;
+import net.minecraftforge.fml.network.NetworkRegistry;
+import net.minecraftforge.fml.network.PacketDistributor;
+import net.minecraftforge.fml.network.simple.SimpleChannel;
 
 public class NetworkContentPackHandler {
 
-    private final EventNetworkChannel channel;
-    private final ResourceLocation channelName;
+    private static final String PROTOCOL_VERSION = "1";
+
     private final ContentPackHandler handler;
+    private final SimpleChannel channel;
 
     public NetworkContentPackHandler(final String modid, final ContentPackHandler handler) {
-        this.channelName = new ResourceLocation(modid, "contentpackhandler");
-        this.channel = NetworkRegistry.newEventChannel(channelName, () -> modid,
-                modid::equalsIgnoreCase, modid::equalsIgnoreCase);
         this.handler = handler;
-        channel.registerObject(this);
+        this.channel = NetworkRegistry.newSimpleChannel(
+                new ResourceLocation(modid, "cpnet"),
+                () -> PROTOCOL_VERSION,
+                PROTOCOL_VERSION::equals,
+                PROTOCOL_VERSION::equals);
+        this.channel.registerMessage(0, HashPacket.class, HashPacket::encode, HashPacket::decode,
+                this::handleHash);
         MinecraftForge.EVENT_BUS.register(this);
     }
 
     @SubscribeEvent
-    public void serverEvent(final ServerCustomPayloadEvent event) {
-        final ByteBuffer buffer = event.getPayload().nioBuffer();
-        final long serverHash = buffer.getLong();
-        if (serverHash != handler.getHash())
-            throw new ContentPackException("Server and Client Hash are not equal!"
-                    + " Please check that you have got the same ContentPacks on Client and Server!"
-                    + " Server Hash: [" + serverHash + "], Client Hash: [" + handler.getHash()
-                    + "]");
-        event.getSource().get().setPacketHandled(true);
+    public void onPlayerLoggedIn(final PlayerEvent.PlayerLoggedInEvent event) {
+        if (event.getPlayer() instanceof ServerPlayerEntity) {
+            final ServerPlayerEntity sp = (ServerPlayerEntity) event.getPlayer();
+            channel.send(PacketDistributor.PLAYER.with(() -> sp), new HashPacket(handler.getHash()));
+        }
     }
 
-    @SubscribeEvent
-    public void onPlayerJoin(final PlayerLoggedInEvent event) {
-        final ByteBuffer buffer = ByteBuffer.allocate(8);
-        buffer.putLong(handler.getHash());
-        sendTo(event.getPlayer(), buffer);
+    private void handleHash(final HashPacket msg, final Supplier<NetworkEvent.Context> ctx) {
+        ctx.get().enqueueWork(() -> {
+            if (msg.hash != handler.getHash()) {
+                throw new ContentPackException("Server and Client Hash are not equal!"
+                        + " Please check that you have got the same ContentPacks on Client and"
+                        + " Server! Server Hash: [" + msg.hash + "], Client Hash: ["
+                        + handler.getHash() + "]");
+            }
+        });
+        ctx.get().setPacketHandled(true);
     }
 
-    private void sendTo(final Player player, final ByteBuffer buf) {
-        final FriendlyByteBuf buffer = new FriendlyByteBuf(Unpooled.copiedBuffer(buf.position(0)));
-        if (player instanceof ServerPlayer) {
-            final ServerPlayer server = (ServerPlayer) player;
-            server.connection.send(new ClientboundCustomPayloadPacket(channelName, buffer));
-        } else {
-            final Minecraft mc = Minecraft.getInstance();
-            mc.getConnection().send(new ServerboundCustomPayloadPacket(channelName, buffer));
+    public static final class HashPacket {
+        public final long hash;
+
+        public HashPacket(final long hash) {
+            this.hash = hash;
+        }
+
+        public static void encode(final HashPacket msg, final PacketBuffer buf) {
+            buf.writeLong(msg.hash);
+        }
+
+        public static HashPacket decode(final PacketBuffer buf) {
+            return new HashPacket(buf.readLong());
         }
     }
 }


### PR DESCRIPTION
The branch was using 1.16.5/1.20-style APIs (Pack, AddPackFindersEvent, ChannelBuilder, PathResourcePack, net.minecraft.network.chat.Component) that don't exist in 1.14.4. Rewrites ContentPackHandler/NetworkContentPackHandler to the 1.14.4 ResourcePackList + SimpleChannel APIs, re-adds CustomFolderPackFinder, and keeps the existing public class names + ContentPackException unchanged.